### PR TITLE
JSON updates

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -34,16 +34,41 @@ module.exports = grammar({
 
     string: $ => token(seq('"', repeat(choice(/[^\\"\n]/, /\\./)), '"')),
 
-    number: $ => token(choice(
-      seq(
-        "0x",
+    number: $ => {
+      const hex_literal = seq(
+        choice('0x', '0X'),
         /[\da-fA-F]+/
-      ),
-      seq(
-        /-?\d+/,
-        optional(seq(".", /\d*/))
       )
-    )),
+
+      const decimal_digits = /\d+/
+      const signed_integer = seq(optional(choice('-','+')), decimal_digits)
+      const exponent_part = seq(choice('e', 'E'), signed_integer)
+
+      const binary_literal = seq(choice('0b', '0B'), /[0-1]+/)
+
+      const octal_literal = seq(choice('0o', '0O'), /[0-7]+/)
+
+      const decimal_integer_literal = seq(
+        optional(choice('-','+')),
+        choice(
+          '0',
+          seq(/[1-9]/, optional(decimal_digits))
+        )
+      )
+
+      const decimal_literal = choice(
+        seq(decimal_integer_literal, '.', optional(decimal_digits), optional(exponent_part)),
+        seq('.', decimal_digits, optional(exponent_part)),
+        seq(decimal_integer_literal, optional(exponent_part))
+      )
+
+      return token(choice(
+        hex_literal,
+        decimal_literal,
+        binary_literal,
+        octal_literal
+      ))
+    },
 
     true: $ => "true",
 

--- a/grammar.js
+++ b/grammar.js
@@ -6,7 +6,7 @@ module.exports = grammar({
   ],
 
   rules: {
-    value: $ => $._value,
+    value: $ => choice($.object, $.array),
 
     _value: $ => choice(
       $.object,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nan": "^2.0.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.7.2"
+    "tree-sitter-cli": "^0.7.4"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2,8 +2,17 @@
   "name": "json",
   "rules": {
     "value": {
-      "type": "SYMBOL",
-      "name": "_value"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "object"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array"
+        }
+      ]
     },
     "_value": {
       "type": "CHOICE",
@@ -197,8 +206,17 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
-                "value": "0x"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "0x"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "0X"
+                  }
+                ]
               },
               {
                 "type": "PATTERN",
@@ -207,32 +225,370 @@
             ]
           },
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "-?\\d+"
-              },
-              {
-                "type": "CHOICE",
+                "type": "SEQ",
                 "members": [
                   {
                     "type": "SEQ",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "."
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "-"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "+"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
                       },
                       {
-                        "type": "PATTERN",
-                        "value": "\\d*"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[1-9]"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\d+"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
                       }
                     ]
                   },
                   {
-                    "type": "BLANK"
+                    "type": "STRING",
+                    "value": "."
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "\\d+"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "e"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "E"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "-"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "+"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "\\d+"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
                   }
                 ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "\\d+"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "e"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "E"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "-"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "+"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "\\d+"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "-"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "+"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "0"
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[1-9]"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\d+"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "e"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "E"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "-"
+                                      },
+                                      {
+                                        "type": "STRING",
+                                        "value": "+"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "\\d+"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "0b"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "0B"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "[0-1]+"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "0o"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "0O"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "[0-7]+"
               }
             ]
           }

--- a/src/parser.c
+++ b/src/parser.c
@@ -143,35 +143,39 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(1);
       if (lookahead == '\"')
         ADVANCE(2);
-      if (lookahead == ',')
+      if (lookahead == '+')
         ADVANCE(5);
-      if (lookahead == '-')
-        ADVANCE(6);
-      if (lookahead == '0')
-        ADVANCE(9);
-      if (lookahead == ':')
+      if (lookahead == ',')
         ADVANCE(12);
-      if (lookahead == '[')
+      if (lookahead == '-')
+        ADVANCE(5);
+      if (lookahead == '.')
         ADVANCE(13);
-      if (lookahead == ']')
+      if (lookahead == '0')
         ADVANCE(14);
+      if (lookahead == ':')
+        ADVANCE(21);
+      if (lookahead == '[')
+        ADVANCE(22);
+      if (lookahead == ']')
+        ADVANCE(23);
       if (lookahead == 'f')
-        ADVANCE(15);
-      if (lookahead == 'n')
-        ADVANCE(20);
-      if (lookahead == 't')
         ADVANCE(24);
-      if (lookahead == '{')
-        ADVANCE(28);
-      if (lookahead == '}')
+      if (lookahead == 'n')
         ADVANCE(29);
+      if (lookahead == 't')
+        ADVANCE(33);
+      if (lookahead == '{')
+        ADVANCE(37);
+      if (lookahead == '}')
+        ADVANCE(38);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ')
         SKIP(0);
       if (('1' <= lookahead && lookahead <= '9'))
-        ADVANCE(7);
+        ADVANCE(11);
       END_STATE();
     case 1:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -194,155 +198,231 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(2);
       END_STATE();
     case 5:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      if (lookahead == '0')
+        ADVANCE(6);
+      if (('1' <= lookahead && lookahead <= '9'))
+        ADVANCE(11);
       END_STATE();
     case 6:
-      if (('0' <= lookahead && lookahead <= '9'))
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.')
         ADVANCE(7);
+      if (lookahead == 'E')
+        ADVANCE(8);
+      if (lookahead == 'e')
+        ADVANCE(8);
       END_STATE();
     case 7:
       ACCEPT_TOKEN(sym_number);
-      if (lookahead == '.')
+      if (lookahead == 'E')
+        ADVANCE(8);
+      if (lookahead == 'e')
         ADVANCE(8);
       if (('0' <= lookahead && lookahead <= '9'))
         ADVANCE(7);
       END_STATE();
     case 8:
-      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '+')
+        ADVANCE(9);
+      if (lookahead == '-')
+        ADVANCE(9);
       if (('0' <= lookahead && lookahead <= '9'))
-        ADVANCE(8);
+        ADVANCE(10);
       END_STATE();
     case 9:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '.')
-        ADVANCE(8);
-      if (lookahead == 'x')
-        ADVANCE(10);
       if (('0' <= lookahead && lookahead <= '9'))
-        ADVANCE(7);
+        ADVANCE(10);
       END_STATE();
     case 10:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f'))
-        ADVANCE(11);
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9'))
+        ADVANCE(10);
       END_STATE();
     case 11:
       ACCEPT_TOKEN(sym_number);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f'))
+      if (lookahead == '.')
+        ADVANCE(7);
+      if (lookahead == 'E')
+        ADVANCE(8);
+      if (lookahead == 'e')
+        ADVANCE(8);
+      if (('0' <= lookahead && lookahead <= '9'))
         ADVANCE(11);
       END_STATE();
     case 12:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 13:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (('0' <= lookahead && lookahead <= '9'))
+        ADVANCE(7);
       END_STATE();
     case 14:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.')
+        ADVANCE(7);
+      if (lookahead == 'B')
+        ADVANCE(15);
+      if (lookahead == 'E')
+        ADVANCE(8);
+      if (lookahead == 'O')
+        ADVANCE(17);
+      if (lookahead == 'X')
+        ADVANCE(19);
+      if (lookahead == 'b')
+        ADVANCE(15);
+      if (lookahead == 'e')
+        ADVANCE(8);
+      if (lookahead == 'o')
+        ADVANCE(17);
+      if (lookahead == 'x')
+        ADVANCE(19);
       END_STATE();
     case 15:
-      if (lookahead == 'a')
+      if (lookahead == '0' ||
+          lookahead == '1')
         ADVANCE(16);
       END_STATE();
     case 16:
-      if (lookahead == 'l')
-        ADVANCE(17);
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '0' ||
+          lookahead == '1')
+        ADVANCE(16);
       END_STATE();
     case 17:
-      if (lookahead == 's')
+      if (('0' <= lookahead && lookahead <= '7'))
         ADVANCE(18);
       END_STATE();
     case 18:
-      if (lookahead == 'e')
-        ADVANCE(19);
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '7'))
+        ADVANCE(18);
       END_STATE();
     case 19:
-      ACCEPT_TOKEN(sym_false);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f'))
+        ADVANCE(20);
       END_STATE();
     case 20:
-      if (lookahead == 'u')
-        ADVANCE(21);
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f'))
+        ADVANCE(20);
       END_STATE();
     case 21:
-      if (lookahead == 'l')
-        ADVANCE(22);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 22:
-      if (lookahead == 'l')
-        ADVANCE(23);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 23:
-      ACCEPT_TOKEN(sym_null);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 24:
-      if (lookahead == 'r')
+      if (lookahead == 'a')
         ADVANCE(25);
       END_STATE();
     case 25:
-      if (lookahead == 'u')
+      if (lookahead == 'l')
         ADVANCE(26);
       END_STATE();
     case 26:
-      if (lookahead == 'e')
+      if (lookahead == 's')
         ADVANCE(27);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(sym_true);
+      if (lookahead == 'e')
+        ADVANCE(28);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      ACCEPT_TOKEN(sym_false);
       END_STATE();
     case 29:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead == 'u')
+        ADVANCE(30);
       END_STATE();
     case 30:
+      if (lookahead == 'l')
+        ADVANCE(31);
+      END_STATE();
+    case 31:
+      if (lookahead == 'l')
+        ADVANCE(32);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(sym_null);
+      END_STATE();
+    case 33:
+      if (lookahead == 'r')
+        ADVANCE(34);
+      END_STATE();
+    case 34:
+      if (lookahead == 'u')
+        ADVANCE(35);
+      END_STATE();
+    case 35:
+      if (lookahead == 'e')
+        ADVANCE(36);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(sym_true);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 39:
       if (lookahead == '\"')
         ADVANCE(2);
+      if (lookahead == '+')
+        ADVANCE(5);
       if (lookahead == '-')
-        ADVANCE(6);
-      if (lookahead == '0')
-        ADVANCE(9);
-      if (lookahead == '[')
+        ADVANCE(5);
+      if (lookahead == '.')
         ADVANCE(13);
-      if (lookahead == ']')
+      if (lookahead == '0')
         ADVANCE(14);
+      if (lookahead == '[')
+        ADVANCE(22);
+      if (lookahead == ']')
+        ADVANCE(23);
       if (lookahead == 'f')
-        ADVANCE(15);
-      if (lookahead == 'n')
-        ADVANCE(20);
-      if (lookahead == 't')
         ADVANCE(24);
-      if (lookahead == '{')
-        ADVANCE(28);
-      if (lookahead == '}')
+      if (lookahead == 'n')
         ADVANCE(29);
+      if (lookahead == 't')
+        ADVANCE(33);
+      if (lookahead == '{')
+        ADVANCE(37);
+      if (lookahead == '}')
+        ADVANCE(38);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ')
-        SKIP(30);
+        SKIP(39);
       if (('1' <= lookahead && lookahead <= '9'))
-        ADVANCE(7);
+        ADVANCE(11);
       END_STATE();
-    case 31:
+    case 40:
       if (lookahead == 0)
         ADVANCE(1);
       if (lookahead == ',')
-        ADVANCE(5);
-      if (lookahead == ':')
         ADVANCE(12);
+      if (lookahead == ':')
+        ADVANCE(21);
       if (lookahead == ']')
-        ADVANCE(14);
+        ADVANCE(23);
       if (lookahead == '}')
-        ADVANCE(29);
+        ADVANCE(38);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ')
-        SKIP(31);
+        SKIP(40);
       END_STATE();
     default:
       return false;
@@ -351,33 +431,33 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 30},
-  [2] = {.lex_state = 30},
-  [3] = {.lex_state = 30},
-  [4] = {.lex_state = 31},
+  [1] = {.lex_state = 0},
+  [2] = {.lex_state = 39},
+  [3] = {.lex_state = 39},
+  [4] = {.lex_state = 0},
   [5] = {.lex_state = 0},
-  [6] = {.lex_state = 0},
-  [7] = {.lex_state = 31},
-  [8] = {.lex_state = 31},
-  [9] = {.lex_state = 31},
-  [10] = {.lex_state = 31},
-  [11] = {.lex_state = 31},
-  [12] = {.lex_state = 30},
-  [13] = {.lex_state = 30},
-  [14] = {.lex_state = 31},
-  [15] = {.lex_state = 31},
-  [16] = {.lex_state = 30},
-  [17] = {.lex_state = 31},
-  [18] = {.lex_state = 31},
-  [19] = {.lex_state = 31},
-  [20] = {.lex_state = 31},
-  [21] = {.lex_state = 30},
-  [22] = {.lex_state = 31},
-  [23] = {.lex_state = 31},
-  [24] = {.lex_state = 30},
-  [25] = {.lex_state = 31},
-  [26] = {.lex_state = 31},
-  [27] = {.lex_state = 31},
+  [6] = {.lex_state = 40},
+  [7] = {.lex_state = 40},
+  [8] = {.lex_state = 40},
+  [9] = {.lex_state = 40},
+  [10] = {.lex_state = 40},
+  [11] = {.lex_state = 40},
+  [12] = {.lex_state = 39},
+  [13] = {.lex_state = 39},
+  [14] = {.lex_state = 40},
+  [15] = {.lex_state = 40},
+  [16] = {.lex_state = 39},
+  [17] = {.lex_state = 40},
+  [18] = {.lex_state = 40},
+  [19] = {.lex_state = 40},
+  [20] = {.lex_state = 40},
+  [21] = {.lex_state = 39},
+  [22] = {.lex_state = 40},
+  [23] = {.lex_state = 40},
+  [24] = {.lex_state = 39},
+  [25] = {.lex_state = 40},
+  [26] = {.lex_state = 40},
+  [27] = {.lex_state = 40},
 };
 
 static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
@@ -396,65 +476,58 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_null] = ACTIONS(1),
   },
   [1] = {
-    [sym_value] = STATE(5),
-    [sym__value] = STATE(6),
-    [sym_object] = STATE(4),
-    [sym_array] = STATE(4),
+    [sym_value] = STATE(4),
+    [sym_object] = STATE(5),
+    [sym_array] = STATE(5),
     [anon_sym_LBRACE] = ACTIONS(5),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_string] = ACTIONS(9),
-    [sym_number] = ACTIONS(11),
-    [sym_true] = ACTIONS(9),
-    [sym_false] = ACTIONS(9),
-    [sym_null] = ACTIONS(9),
   },
   [2] = {
-    [sym_pair] = STATE(9),
-    [anon_sym_RBRACE] = ACTIONS(13),
-    [sym_string] = ACTIONS(15),
-    [sym_number] = ACTIONS(17),
+    [sym_pair] = STATE(8),
+    [anon_sym_RBRACE] = ACTIONS(9),
+    [sym_string] = ACTIONS(11),
+    [sym_number] = ACTIONS(13),
   },
   [3] = {
     [sym__value] = STATE(11),
-    [sym_object] = STATE(4),
-    [sym_array] = STATE(4),
+    [sym_object] = STATE(10),
+    [sym_array] = STATE(10),
     [anon_sym_LBRACE] = ACTIONS(5),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(19),
-    [sym_string] = ACTIONS(9),
-    [sym_number] = ACTIONS(11),
-    [sym_true] = ACTIONS(9),
-    [sym_false] = ACTIONS(9),
-    [sym_null] = ACTIONS(9),
+    [anon_sym_RBRACK] = ACTIONS(15),
+    [sym_string] = ACTIONS(17),
+    [sym_number] = ACTIONS(19),
+    [sym_true] = ACTIONS(17),
+    [sym_false] = ACTIONS(17),
+    [sym_null] = ACTIONS(17),
   },
   [4] = {
     [ts_builtin_sym_end] = ACTIONS(21),
-    [anon_sym_COMMA] = ACTIONS(21),
-    [anon_sym_RBRACE] = ACTIONS(21),
-    [anon_sym_RBRACK] = ACTIONS(21),
   },
   [5] = {
     [ts_builtin_sym_end] = ACTIONS(23),
   },
   [6] = {
     [ts_builtin_sym_end] = ACTIONS(25),
+    [anon_sym_COMMA] = ACTIONS(25),
+    [anon_sym_RBRACE] = ACTIONS(25),
+    [anon_sym_RBRACK] = ACTIONS(25),
   },
   [7] = {
-    [ts_builtin_sym_end] = ACTIONS(27),
-    [anon_sym_COMMA] = ACTIONS(27),
-    [anon_sym_RBRACE] = ACTIONS(27),
-    [anon_sym_RBRACK] = ACTIONS(27),
+    [anon_sym_COLON] = ACTIONS(27),
   },
   [8] = {
-    [anon_sym_COLON] = ACTIONS(29),
+    [aux_sym_object_repeat1] = STATE(15),
+    [anon_sym_COMMA] = ACTIONS(29),
+    [anon_sym_RBRACE] = ACTIONS(31),
   },
   [9] = {
-    [aux_sym_object_repeat1] = STATE(15),
-    [anon_sym_COMMA] = ACTIONS(31),
+    [ts_builtin_sym_end] = ACTIONS(33),
+    [anon_sym_COMMA] = ACTIONS(33),
     [anon_sym_RBRACE] = ACTIONS(33),
+    [anon_sym_RBRACK] = ACTIONS(33),
   },
   [10] = {
-    [ts_builtin_sym_end] = ACTIONS(35),
     [anon_sym_COMMA] = ACTIONS(35),
     [anon_sym_RBRACE] = ACTIONS(35),
     [anon_sym_RBRACK] = ACTIONS(35),
@@ -466,20 +539,20 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
   },
   [12] = {
     [sym__value] = STATE(19),
-    [sym_object] = STATE(4),
-    [sym_array] = STATE(4),
+    [sym_object] = STATE(10),
+    [sym_array] = STATE(10),
     [anon_sym_LBRACE] = ACTIONS(5),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_string] = ACTIONS(9),
-    [sym_number] = ACTIONS(11),
-    [sym_true] = ACTIONS(9),
-    [sym_false] = ACTIONS(9),
-    [sym_null] = ACTIONS(9),
+    [sym_string] = ACTIONS(17),
+    [sym_number] = ACTIONS(19),
+    [sym_true] = ACTIONS(17),
+    [sym_false] = ACTIONS(17),
+    [sym_null] = ACTIONS(17),
   },
   [13] = {
     [sym_pair] = STATE(20),
-    [sym_string] = ACTIONS(15),
-    [sym_number] = ACTIONS(17),
+    [sym_string] = ACTIONS(11),
+    [sym_number] = ACTIONS(13),
   },
   [14] = {
     [ts_builtin_sym_end] = ACTIONS(41),
@@ -493,15 +566,15 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
   },
   [16] = {
     [sym__value] = STATE(23),
-    [sym_object] = STATE(4),
-    [sym_array] = STATE(4),
+    [sym_object] = STATE(10),
+    [sym_array] = STATE(10),
     [anon_sym_LBRACE] = ACTIONS(5),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_string] = ACTIONS(9),
-    [sym_number] = ACTIONS(11),
-    [sym_true] = ACTIONS(9),
-    [sym_false] = ACTIONS(9),
-    [sym_null] = ACTIONS(9),
+    [sym_string] = ACTIONS(17),
+    [sym_number] = ACTIONS(19),
+    [sym_true] = ACTIONS(17),
+    [sym_false] = ACTIONS(17),
+    [sym_null] = ACTIONS(17),
   },
   [17] = {
     [ts_builtin_sym_end] = ACTIONS(47),
@@ -523,8 +596,8 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
   },
   [21] = {
     [sym_pair] = STATE(26),
-    [sym_string] = ACTIONS(15),
-    [sym_number] = ACTIONS(17),
+    [sym_string] = ACTIONS(11),
+    [sym_number] = ACTIONS(13),
   },
   [22] = {
     [ts_builtin_sym_end] = ACTIONS(57),
@@ -538,15 +611,15 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
   },
   [24] = {
     [sym__value] = STATE(27),
-    [sym_object] = STATE(4),
-    [sym_array] = STATE(4),
+    [sym_object] = STATE(10),
+    [sym_array] = STATE(10),
     [anon_sym_LBRACE] = ACTIONS(5),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_string] = ACTIONS(9),
-    [sym_number] = ACTIONS(11),
-    [sym_true] = ACTIONS(9),
-    [sym_false] = ACTIONS(9),
-    [sym_null] = ACTIONS(9),
+    [sym_string] = ACTIONS(17),
+    [sym_number] = ACTIONS(19),
+    [sym_true] = ACTIONS(17),
+    [sym_false] = ACTIONS(17),
+    [sym_null] = ACTIONS(17),
   },
   [25] = {
     [ts_builtin_sym_end] = ACTIONS(61),
@@ -570,20 +643,20 @@ static TSParseActionEntry ts_parse_actions[] = {
   [3] = {.count = 1, .reusable = true, .depends_on_lookahead = true}, RECOVER(),
   [5] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(2),
   [7] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(3),
-  [9] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(4),
-  [11] = {.count = 1, .reusable = true, .depends_on_lookahead = true}, SHIFT(4),
-  [13] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(7),
-  [15] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(8),
-  [17] = {.count = 1, .reusable = true, .depends_on_lookahead = true}, SHIFT(8),
-  [19] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(10),
-  [21] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym__value, 1),
-  [23] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, ACCEPT_INPUT(),
-  [25] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym_value, 1),
-  [27] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym_object, 2),
-  [29] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(12),
-  [31] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(13),
-  [33] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(14),
-  [35] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym_array, 2),
+  [9] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(6),
+  [11] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(7),
+  [13] = {.count = 1, .reusable = true, .depends_on_lookahead = true}, SHIFT(7),
+  [15] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(9),
+  [17] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(10),
+  [19] = {.count = 1, .reusable = true, .depends_on_lookahead = true}, SHIFT(10),
+  [21] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, ACCEPT_INPUT(),
+  [23] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym_value, 1),
+  [25] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym_object, 2),
+  [27] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(12),
+  [29] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(13),
+  [31] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(14),
+  [33] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym_array, 2),
+  [35] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym__value, 1),
   [37] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(16),
   [39] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, SHIFT(17),
   [41] = {.count = 1, .reusable = true, .depends_on_lookahead = false}, REDUCE(sym_object, 3),


### PR DESCRIPTION
Expands the definition of `number`, and adds a required top-level node called value.

@maxbrunsfeld The definition of `number` differs from the `tree-sitter-javascript` implementation in that this one parses `-` or `+` before `decimal_integer_literal`. I think that's handled by `unary_expression` in JS.