### PR TITLE
Use the default compiler on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 language: node_js
-sudo: false
-node_js:
-  - "node"
-compiler: clang-3.6
-env:
-  - CXX=clang-3.6
-addons:
-  apt:
-    sources:
-      - llvm-toolchain-precise-3.6
-      - ubuntu-toolchain-r-test
-    packages:
-      - clang-3.6
+
+node_js: 10
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
CI is [currently failing on the master branch](https://travis-ci.org/tree-sitter/tree-sitter-json/builds/461924279). Let's fix that.

This same change seemed to get CI working again in tree-sitter-javascript (https://github.com/tree-sitter/tree-sitter-javascript/commit/aeb4399be10d80c5aac5880e9a75541494d335fb), so let's try it for tree-sitter-json.