### PR TITLE
⬆️ tree-sitter-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nan": "^2.0.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.13.1"
+    "tree-sitter-cli": "^0.14.1"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",


### PR DESCRIPTION
CI is [currently failing on the master branch](https://travis-ci.org/tree-sitter/tree-sitter-json/builds/461924279). Let's fix that.

In https://github.com/tree-sitter/tree-sitter-json/pull/9#issuecomment-494912786, @maxbrunsfeld noted that the failure may be due to using the old version of tree-sitter-cli. This pull request upgrades to the latest version in the 0.14.x series.