### PR TITLE
Semantic capture names

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,9 +1,16 @@
 (pair
-  key: (_) @keyword)
+  key: (_) @string.special.key)
 
 (string) @string
 
-(object
-  "{" @escape
-  (_)
-  "}" @escape)
+(number) @number
+
+[
+  (null)
+  (true)
+  (false)
+] @constant.builtin
+
+(escape_sequence) @escape
+
+(comment) @comment


### PR DESCRIPTION
I've been experimenting with this parser, and I was surprised to see the definitions in `highlights.scm`. There are a number of important elements missing. And the ones that are there don't match the conventions used in other parsers.

I took a stab at correcting it.