### PR TITLE
chore: pnpm support, add node-gyp to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "nan": "^2.14.1"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.1"
+    "tree-sitter-cli": "^0.19.1",
+    "node-gyp": "^7.1.2"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",


### PR DESCRIPTION
https://github.com/pnpm/pnpm/blob/f53a29d76f657f1b3785e873f0ac9b7291c007e4/exec/lifecycle/src/index.ts#LL57C6-L57C6
https://github.com/pnpm/npm-lifecycle/blob/ea49e3600279bcf70f09871bbba6ee4b8c5c6f7d/node-gyp-bin/node-gyp#L3

to use `node-gyp`, it should be in package's dependencies